### PR TITLE
参加済みのコミュニティに再び「参加する」をした時に起きるエラーを解消

### DIFF
--- a/app/controllers/communities/joinings_controller.rb
+++ b/app/controllers/communities/joinings_controller.rb
@@ -28,7 +28,7 @@ class Communities::JoiningsController < ApplicationController
   # POST /communities/joinings
   # POST /communities/joinings.json
   def create
-    @communities_joining =Joining.new(communities_joining_params)
+    @communities_joining = Joining.new(communities_joining_params)
 
     @communities_joining.community_id = params[:community_id]
     @communities_joining.user_id = current_user.id
@@ -38,6 +38,7 @@ class Communities::JoiningsController < ApplicationController
         format.html { redirect_to [@communities_joining.community, @communities_joining], notice: 'Joining was successfully created.' }
         format.json { render :show, status: :created, location: @communities_joining }
       else
+        @community = Community.find params[:community_id]
         format.html { render :new }
         format.json { render json: @communities_joining.errors, status: :unprocessable_entity }
       end


### PR DESCRIPTION
エラー発生オペレーション
1. Community > [このコミュニティに参加する]
2. Homeにもどる
3. Community > [このコミュニティに参加する]
4. views/communities/joins/_fome で @community がnilのためにエラー発生
