### PR TITLE
current_user=nilの時に、communitys/indexが表示できないのを修正

### DIFF
--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -5,7 +5,7 @@ class Community < ActiveRecord::Base
   has_many :backgrounds
 
   def has_member?(user)
-    self.joinings.where(user_id: user.id).length > 0
+    user.present? and self.joinings.where(user_id: user.id).length > 0
   end
 
   def is_owner?(user)


### PR DESCRIPTION
current_userが設定されていない時にCommunity#has_menber(user)のuser.idで
undefind method nil
となっていたために起きていたエラーに対応。
