### PR TITLE
右上メニューのチャットリンクからロビー用チャット移動時にwebsocket接続にならないのを修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem 'coffee-rails', '~> 4.0.0'
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 gem 'jquery-ui-rails'
+gem 'jquery-turbolinks'
 # Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
 gem 'turbolinks'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,6 +179,9 @@ GEM
     jquery-rails (3.1.1)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
+    jquery-turbolinks (2.1.0)
+      railties (>= 3.1.0)
+      turbolinks
     jquery-ui-rails (5.0.0)
       railties (>= 3.2.16)
     json (1.8.1)
@@ -417,6 +420,7 @@ DEPENDENCIES
   hirb-unicode
   jbuilder (~> 2.0)
   jquery-rails
+  jquery-turbolinks
   jquery-ui-rails
   less-rails
   letter_opener

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,6 +12,7 @@
 //
 //= require jquery
 //= require turbolinks
+//= require jquery.turbolinks
 //= require jquery_ujs
 //= require jquery-ui
 


### PR DESCRIPTION
gem jquery-turbolinks
を使って、turbolinksでのページ遷移時にもwindow.onloadイベントが発火するようにした
